### PR TITLE
Fix: Remove Interface folder if a namespace is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CSR stands for Controller/Service/Repository. This package lets you set all that
 
 Install the package using composer:
 ```
-composer require scrumble-nl/laravel-csr
+composer require hassanejazpvt/laravel-csr
 ```
 
 Publish the configuration file for default class paths:

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
 		]
 	},
 	"require": {
-		"php": ">=8.0",
-		"laravel/framework": "^9.0"
+		"php": ">=7.3",
+		"laravel/framework": "^8.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~9.3"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-	"name": "scrumble-nl/laravel-csr",
+	"name": "hassanejazpvt/laravel-csr",
 	"type": "library",
-	"homepage": "https://github.com/scrumble-nl/laravel-csr",
+	"homepage": "https://github.com/hassanejazpvt/laravel-csr",
 	"description": "This package makes it possible to generate a controller, service, repository, model and migration all in 1 command",
 	"keywords": [
 		"command",

--- a/src/Commands/CreateCsr.php
+++ b/src/Commands/CreateCsr.php
@@ -157,12 +157,14 @@ class CreateCsr extends Command
             'name' => config('csr.paths.repository_interface') . '/' . $namespace . '/I' . $name . 'Repository',
             'basename' => $name,
             'namespace' => $namespace,
+            'model' => $this->option('model')
         ]);
 
         $this->call('csr:repository', [
             'name' => config('csr.paths.repository') . '/' . $namespace . '/' . $name . 'Repository',
             'basename' => $name,
             'namespace' => $namespace,
+            'model' => $this->option('model')
         ]);
     }
 

--- a/src/Commands/stubs/abstract/imodelRepository.stub
+++ b/src/Commands/stubs/abstract/imodelRepository.stub
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DummyNamespace;
+
+use App\{{NamespaceShort}}{{BaseName}};
+
+interface {{Variable}}
+{
+    /**
+     * @var {{BaseName}}
+     */
+    private $model;
+
+    /**
+     * @param {{BaseName}} ${{baseName}}
+     */
+    public function __construct({{BaseName}} ${{baseName}}) { }
+}

--- a/src/Commands/stubs/concrete/controller.stub
+++ b/src/Commands/stubs/concrete/controller.stub
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DummyNamespace;
 
 use App\Http\Controllers\Controller;
-use App\Interfaces\Services\{{NamespaceShort}}I{{BaseName}}Service;
+use App\{{IServicesPath}}{{NamespaceShort}}I{{BaseName}}Service;
 
 class {{Variable}} extends Controller
 {

--- a/src/Commands/stubs/concrete/modelRepository.stub
+++ b/src/Commands/stubs/concrete/modelRepository.stub
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DummyNamespace;
+
+use App\{{NamespaceShort}}{{BaseName}};
+use App\{{IRepositoriesPath}}{{NamespaceShort}}I{{Variable}};
+
+class {{Variable}} implements I{{Variable}}
+{
+    /**
+     * @var {{BaseName}}
+     */
+    private $model;
+
+    /**
+     * @param {{BaseName}} ${{baseName}}
+     */
+    public function __construct({{BaseName}} ${{baseName}})
+    {
+        $this->model = ${{baseName}};
+    }
+}

--- a/src/Commands/stubs/concrete/repository.stub
+++ b/src/Commands/stubs/concrete/repository.stub
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DummyNamespace;
 
-use App\Interfaces\Repositories\{{NamespaceShort}}I{{Variable}};
+use App\{{IRepositoriesPath}}{{NamespaceShort}}I{{Variable}};
 
 class {{Variable}} implements I{{Variable}}
 {

--- a/src/Commands/stubs/concrete/service.stub
+++ b/src/Commands/stubs/concrete/service.stub
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace DummyNamespace;
 
-use App\Interfaces\Services\{{NamespaceShort}}I{{BaseName}}Service;
-use App\Interfaces\Repositories\{{NamespaceShort}}I{{BaseName}}Repository;
+use App\{{IServicesPath}}{{NamespaceShort}}I{{BaseName}}Service;
+use App\{{IRepositoriesPath}}{{NamespaceShort}}I{{BaseName}}Repository;
 
 class {{Variable}} implements I{{Variable}}
 {

--- a/src/Commands/subcommands/CreateIRepository.php
+++ b/src/Commands/subcommands/CreateIRepository.php
@@ -32,6 +32,10 @@ class CreateIRepository extends CsrGeneratorCommand
      */
     protected function getStub(): string
     {
-        return __DIR__ . '/../stubs/abstract/irepository.stub';
+        if ($this->argument('model')) {
+            return __DIR__ . '/../stubs/abstract/imodelRepository.stub';
+        } else {
+            return __DIR__ . '/../stubs/abstract/irepository.stub';
+        }
     }
 }

--- a/src/Commands/subcommands/CreateRepository.php
+++ b/src/Commands/subcommands/CreateRepository.php
@@ -32,6 +32,10 @@ class CreateRepository extends CsrGeneratorCommand
      */
     protected function getStub(): string
     {
-        return __DIR__ . '/../stubs/concrete/repository.stub';
+        if ($this->argument('model')) {
+            return __DIR__ . '/../stubs/concrete/modelRepository.stub';
+        } else {
+            return __DIR__ . '/../stubs/concrete/repository.stub';
+        }
     }
 }

--- a/src/Commands/subcommands/CsrGeneratorCommand.php
+++ b/src/Commands/subcommands/CsrGeneratorCommand.php
@@ -54,7 +54,9 @@ abstract class CsrGeneratorCommand extends GeneratorCommand
         $replace = $this->buildReplacements($replace);
 
         return str_replace(
-            array_keys($replace), array_values($replace), parent::buildClass($name)
+            array_keys($replace),
+            array_values($replace),
+            parent::buildClass($name)
         );
     }
 
@@ -74,7 +76,9 @@ abstract class CsrGeneratorCommand extends GeneratorCommand
             '{{BaseName}}' => $baseName,
             '{{baseName}}' => lcfirst($baseName),
             '{{Variable}}' => ucfirst(class_basename($className)),
-            '{{NamespaceShort}}' => $namespace ? ucfirst(strtolower($namespace)) . '\\' : '',
+            '{{NamespaceShort}}'     => $namespace ? ucfirst(strtolower($namespace)) . '\\' : '',
+            '{{IServicesPath}}'      => $namespace ? '' : 'Interfaces\\Services\\',
+            '{{IRepositoriesPath}}'  => $namespace ? '' : 'Interfaces\\Repositories\\',
         ]);
     }
 


### PR DESCRIPTION
Hi

I found a small bug where `Interfaces\Services\` & `Interfaces\Repositories\` namespaces were being used in the controller and service file when `namespace` is provided to the `csr:generate` command.

It was causing interface not found error as the interfaces were being placed in the same namespace folder.