### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 	},
 	"require": {
 		"php": ">=8.1",
-		"laravel/framework": "^10.0|^11.0|^12.0"
+		"laravel/framework": "^10.0|^11.0|^12.0|^13.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.6.0 || ^10.0.1"


### PR DESCRIPTION
- Add `^13.0` to `laravel/framework` (additive; keeps Laravel 10-12).
- No test/CI changes (package has none).